### PR TITLE
修复MSVC 2017 编译错误

### DIFF
--- a/components/TextGroup/RgbStringTransform/cpp/rgbstringtransform.cpp
+++ b/components/TextGroup/RgbStringTransform/cpp/rgbstringtransform.cpp
@@ -28,6 +28,11 @@ QString Manage::getHexString(const QString &red, const QString &green, const QSt
     return color.name();
 }
 
+QString Manage::getHexString(QColor color)
+{
+    return color.name();
+}
+
 QString Manage::getRed(const QString &hexString)
 {
     QColor color( hexString );

--- a/components/TextGroup/RgbStringTransform/cpp/rgbstringtransform.h
+++ b/components/TextGroup/RgbStringTransform/cpp/rgbstringtransform.h
@@ -38,6 +38,7 @@ public slots:
     QString getHexStringFromColorName(const QString &colorName);
 
     QString getHexString(const QString &red, const QString &green, const QString &blue);
+    QString getHexString(QColor color);
 
     QString getRed(const QString &hexString);
 

--- a/components/TextGroup/RgbStringTransform/qml/RgbStringTransform.qml
+++ b/components/TextGroup/RgbStringTransform/qml/RgbStringTransform.qml
@@ -13,8 +13,10 @@
 import QtQuick 2.7
 import QtQuick.Controls 1.4
 import QtGraphicalEffects 1.0
+import QtQuick.Dialogs 1.3
 import "qrc:/MaterialUI/Interface/"
 import RgbStringTransform 1.0
+
 
 Item {
     id: rgbStringTransform
@@ -137,6 +139,26 @@ Item {
                 textFieldForHexString.text = rgbStringTransformManage.getHexString( textFiedForRed.text, textFiedForGreen.text, textFiedForBlue.text );
 
                 rgbStringTransform.changingFlag = false;
+            }
+        }
+
+        MaterialButton {
+            x: 387
+            y: 130
+            width: 120
+            text: "颜色对话框获取"
+
+            onClicked: {
+                colorDialog.open();
+            }
+        }
+
+        ColorDialog {
+            id: colorDialog
+            title: "选择一个颜色"
+            onAccepted: {
+                textFieldForHexString.text = rgbStringTransformManage.getHexString(colorDialog.color);
+                materialUI.showSnackbarMessage( "已从颜色对话框获取颜色" );
             }
         }
 

--- a/library/JQLibrary/JQQRCodeReader.pri
+++ b/library/JQLibrary/JQQRCodeReader.pri
@@ -198,6 +198,8 @@ equals(JQQRCODEREADER_COMPILE_MODE,SRC) {
 
         SOURCES *= \
             $$PWD/src/JQQRCodeReader/zxing/win32/zxing/win_iconv.c
+
+        DEFINES*=__STDC_LIMIT_MACROS
     }
 }
 else : equals(JQQRCODEREADER_COMPILE_MODE,LIB) {


### PR DESCRIPTION
未添加__STDC_LIMIT_MACROS 会造成找不到 INTMAX_MAX宏定义